### PR TITLE
BUGFIX: Remove non used namespace

### DIFF
--- a/Configuration/Settings.Workbox.yaml
+++ b/Configuration/Settings.Workbox.yaml
@@ -4,7 +4,7 @@ DIU:
       Workbox:
         globDirectory: 'Web/'
         globPatterns:
-#          - '_Resources/Static/Packages/{DIU,Sitegeist}.*/**/*.{js,css,gif,jpg,svg,png,webp,woff,woff2}'
+#          - '_Resources/Static/Packages/{DIU}.*/**/*.{js,css,gif,jpg,svg,png,webp,woff,woff2}'
         globFollow: true
         swDest: 'Web/sw.js'
 


### PR DESCRIPTION
Seems to be a package namespace that has been overlooked. As the package it self does not has any sitegeist package as dependency it is maybe a relict of a project job ;)